### PR TITLE
Add colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="./assets/teaser.png">
 </div>
 
-### [Paper](https://arxiv.org/abs/1907.10830) | [Official Pytorch code](https://github.com/znxlwm/UGATIT-pytorch)
+### [Paper](https://arxiv.org/abs/1907.10830) | [Official Pytorch code](https://github.com/znxlwm/UGATIT-pytorch) | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taki0112/UGATIT/blob/master/UGATIT.ipynb)
 
 The results of the paper came from the **Tensorflow code**
 

--- a/UGATIT.ipynb
+++ b/UGATIT.ipynb
@@ -1,0 +1,154 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "UGATIT",
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/bkkaggle/UGATIT/blob/master/UGATIT.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TRm-USlsHgEV",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!git clone https://github.com/taki0112/UGATIT.git"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Pt3igws3eiVp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import os\n",
+        "os.chdir('UGATIT/')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1T3dTGnfI8NW",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import os\n",
+        "os.environ['KAGGLE_USERNAME'] = \"[USERNAME]\" # Add your kaggle username and api key to download the pretrained model\n",
+        "os.environ['KAGGLE_KEY'] = \"[API_KEY]\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "smm2E6E7om-c",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!kaggle datasets download -d waifuai/ugatit-cat2dog-pretrained-model"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QgvKlHPEovME",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!unzip ugatit-cat2dog-pretrained-model.zip"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8Rq_pPerfZyr",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!mkdir dataset\n",
+        "!mkdir dataset/cat2dog\n",
+        "!mkdir dataset/cat2dog/testA dataset/cat2dog/testB dataset/cat2dog/trainA dataset/cat2dog/trainB"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "x5idms3Hm5kg",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!wget -O ./dataset/cat2dog/testA/test.jpg https://a57.foxnews.com/static.foxnews.com/foxnews.com/content/uploads/2019/07/931/524/creepy-cat.jpg?ve=1&tl=1"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Vu8eXLTFHvnn",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!python main.py --dataset cat2dog --phase test --light=True --smoothing=False"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "liG0TbXMq5I2",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "img = plt.imread('results/UGATIT_light_cat2dog_lsgan_4resblock_6dis_1_1_10_10_1000_sn/test.jpg')\n",
+        "plt.imshow(img)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
I've added a colab notebook with instructions on how to test out UGATIT on the cat2dog pretrained model from [kaggle](https://www.kaggle.com/waifuai/ugatit-cat2dog-pretrained-model).

I also added an "Open In Colab" badge to the README that will open up the notebook at (https://github.com/taki0112/UGATIT/blob/master/UGATIT.ipynb) in colab. The button in the README won't work until the pull request has been merged in, but you can take a look at the notebook [here](https://github.com/bkkaggle/UGATIT/blob/master/UGATIT.ipynb)